### PR TITLE
Fix variable names and loop in main

### DIFF
--- a/include/pid.c
+++ b/include/pid.c
@@ -1,6 +1,6 @@
 /*working variables*/
 unsigned long lastTime;
-double Input, Output, Setpoint;
+double input, output, Setpoint;
 double errSum, lastErr;
 double kp, ki, kd;
 void Compute()
@@ -10,12 +10,12 @@ unsigned long now = millis();
 double timeChange = (double)(now - lastTime);
  
 /*Compute all the working error variables*/
-double error = Setpoint - Input;
+double error = Setpoint - input;
 errSum += (error * timeChange);
 double dErr = (error - lastErr) / timeChange;
  
 /*Compute PID Output*/
-Output = kp * error + ki * errSum + kd * dErr;
+output = kp * error + ki * errSum + kd * dErr;
  
 /*Remember some variables for next time*/
 lastErr = error;


### PR DESCRIPTION
## Summary
- fix mismatched variable names in `main.c`
- correct the main loop logic and PID compute call
- update PID implementation to use consistent variable names

## Testing
- `gcc -Wall -Iinclude -c src/main.c -o main.o` *(fails: pico/stdlib.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_683fef0c3e90832697ce2df7eaaa5606