### PR TITLE
Add rotary dial calibration

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,3 +5,9 @@ Harware used:
 * CBR600RR fuel pump
 * Fuel pressure sensor from Ford focus
 * Rotary dial for pressure adjustment
+
+## Rotary dial calibration
+
+The firmware now calibrates the rotary dial on start-up. Rotate the dial across
+its full range during the first two seconds after power on. The dial position is
+then used to select between three different variants.


### PR DESCRIPTION
## Summary
- calibrate rotary dial at startup
- choose variant based on calibrated rotary dial position
- document the calibration procedure

## Testing
- `gcc -c src/main.c -Iinclude` *(fails: fatal error: pico/stdlib.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68400c6cfa38832683e8b4698e053b0f